### PR TITLE
Get (currently) macOS 12 as macos-latest for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
See https://github.com/actions/runner-images/pull/6901.

Now that macos-latest provides macOS 12 and no longer warns that it is about to be changed to it, use the macos-latest name.

This has the advantage that it will move up to a newer version eventually, and that it will warn before doing so (as from 11 to 12).