### PR TITLE
Add CI tests that repackage first

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,8 @@ name: Run Unit Tests
 on: [push, pull_request]
 
 jobs:
-  tests:
-    name: Test
+  test-prepackaged:
+    name: Test Prepackaged
 
     strategy:
       fail-fast: false
@@ -14,5 +14,29 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: 'actions/checkout@v3'
-      - run: dotnet test
+      - name: 'Checkout repository'
+        uses: 'actions/checkout@v3'
+      - name: 'Test against old packages'
+        run: dotnet test
+
+  repackage-and-test:
+    name: Repackage and Test
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: 'Checkout repository'
+        uses: 'actions/checkout@v3'
+      - name: 'Full clean and repackage'
+        run: scripts/repackage
+      - name: 'Test against new packages'
+        run: dotnet test

--- a/scripts/repackage
+++ b/scripts/repackage
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -eu
-shopt -s globstar nullglob
+shopt -s nullglob
 
 msg() {
     if test -t 1; then
@@ -22,7 +22,7 @@ if ! test -f NuHello.sln; then
 fi
 
 msg 'Deleting built package files and clearing NuGet cache.'
-rm -rf -- **/{bin,obj} publish/* src/Goodbye/*.nupkg
+rm -rf {src,test}/*/{bin,obj} publish/* src/Goodbye/*.nupkg
 dotnet nuget locals all --clear
 nl
 


### PR DESCRIPTION
I'm keeping the old ones, since I do still want to test against the packages shipped in the repository.