### PR TITLE
Port the repackage script to PowerShell

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
                 "mads-hartmann.bash-ide-vscode",
                 "mhutchie.git-graph",
                 "ms-dotnettools.csharp",
+                "ms-vscode.PowerShell",
                 "ms-vsliveshare.vsliveshare",
                 "stkb.rewrap",
                 "streetsidesoftware.code-spell-checker",

--- a/.devcontainer/postCreate
+++ b/.devcontainer/postCreate
@@ -66,9 +66,11 @@ msg '...fish customized.'
 
 nl
 msg 'Customizing pwsh (PowerShell)...'
+pwsh -c 'Update-Help'
 pwsh -c 'Set-PSRepository PSGallery -InstallationPolicy Trusted'
 pwsh -c 'Install-Module -Name posh-git'
 pwsh -c 'Add-PoshGitToProfile -AllHosts'
+pwsh -c 'Install-Module -Name PSScriptAnalyzer'
 msg '...pwsh customized.'
 
 nl

--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -12,10 +12,12 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+
     permissions:
       actions: read
       contents: read
       security-events: write
+
     strategy:
       fail-fast: false
 

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Upload SARIF output to GitHub Security Center
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: infer-out/report.sarif
+          sarif_file: report.sarif
 
       - name: PSScriptAnalyzer analysis results
         run: |

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -20,7 +20,6 @@ jobs:
 
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@v1.1
-        id: runpsscriptanalyzer
         with:
           path: './'
           recurse: true
@@ -30,9 +29,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: report.sarif
-
-      - name: PSScriptAnalyzer analysis results
-        run: |
-          cat <<'EOF'
-          ${{ steps.runpsscriptanalyzer.outputs.results }}
-          EOF

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -1,0 +1,38 @@
+name: PSScriptAnalyzer
+
+on: [push, pull_request]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Run PSScriptAnalyzer
+        uses: microsoft/psscriptanalyzer-action@v1.1
+        id: runpsscriptanalyzer
+        with:
+          path: './'
+          recurse: true
+          output: report.sarif
+
+      - name: Upload SARIF output to GitHub Security Center
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: infer-out/report.sarif
+
+      - name: PSScriptAnalyzer analysis results
+        run: |
+          cat <<'EOF'
+          ${{ steps.runpsscriptanalyzer.outputs.results }}
+          EOF

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: 'Checkout repository'
+      - name: 'Check out repository'
         uses: 'actions/checkout@v3'
       - name: 'Test against old packages'
         run: dotnet test
@@ -23,20 +23,22 @@ jobs:
     name: Repackage and Test
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        shell: [bash, pwsh]
+        include:
+          - shell: bash
+            script: repackage
+          - shell: pwsh
+            script: repackage.ps1
 
     runs-on: ${{ matrix.os }}
 
-    defaults:
-      run:
-        shell: bash
-
     steps:
-      - name: 'Checkout repository'
+      - name: 'Check out repository'
         uses: 'actions/checkout@v3'
       - name: 'Full clean and repackage'
-        run: scripts/repackage
+        run: ${{ matrix.shell }} scripts/${{ matrix.script }}
       - name: 'Test against new packages'
         run: dotnet test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,8 @@
         "mhutchie",
         "nupkg",
         "nutest",
+        "runinfersharp",
+        "SARIF",
         "shellcheck",
         "stkb",
         "timonwong"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
         "mhutchie",
         "nupkg",
         "nutest",
+        "pwsh",
         "runinfersharp",
         "SARIF",
         "shellcheck",

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ a restore, such as `dotnet build`, will take care of doing the restore, so you
 don’t have to run `dotnet restore` manually before running `dotnet build`, even
 if you’ve just cleared your local NuGet caches.)
 
-## src/Hello &ndash; Ekgn.NuHello
+## src/Hello – Ekgn.NuHello
 
 The NuGet package `Ekgn.NuHello`, generated from the project
 `src/Hello/Hello.csproj`, is a very simple library, consisting of a static
@@ -209,12 +209,12 @@ To do this in LINQPad:
    limited NuGet search functionality within LINQPad. That’s no problem.
 3. At the bottom of the *LINQPad NuGet Manager* window, there is a drop-down
    menu, in which “NuGet 3 official package source” is most likely selected.
-   Click that drop-down menu and select “(configure sources&hellip;)”.
+   Click that drop-down menu and select “(configure sources…)”.
 4. In the *NuGet Settings* dialog, in the “Package Sources” tab, near the
    bottom, put in any name you like for “Name” and the full (absolute) path to
    the local NuGet package source directory in “Source”. (You can select the
-   source by clicking the “&hellip;” button and navigating to it in a file
-   picker dialog.)
+   source by clicking the “…” button and navigating to it in a file picker
+   dialog.)
 5. Click “Save”. It’s fine for the local package source to be listed under the
    official remote one (unless someone publishes a different package, also
    called `Ekgn.NuHello`, to nuget.org).
@@ -238,7 +238,7 @@ file `Hello-nutest.linq` in a text editor. This lets you see its XML header:
 </Query>
 ```
 
-## src/Goodbye &ndash; Ekgn.NuHello.Goodbye
+## src/Goodbye – Ekgn.NuHello.Goodbye
 
 The NuGet package `Ekgn.NuHello.Goodbye`, generated from the directory
 `src/Goodbye` (using `Ekgn.NuHello.Goodbye.nuspec`), is not even a library.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2021 Eliah Kagan
+  Copyright (c) 2021, 2023 Eliah Kagan
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted.
@@ -149,9 +149,9 @@ the top-level directory of the working tree (the `NuHello` directory, unless
 you named it something else when you cloned the repository).
 
 ```powershell
-cd src\Hello
+cd src/Hello
 dotnet build
-nuget add .\bin\Debug\Ekgn.NuHello.1.0.0.nupkg -source ..\..\publish
+nuget add bin/Debug/Ekgn.NuHello.1.0.0.nupkg -source ../../publish
 ```
 
 ## test/Hello.Test
@@ -163,7 +163,7 @@ than using it through NuGet.
 If you wanted to run just that test:
 
 ```powershell
-cd test\Hello.Test
+cd test/Hello.Test
 dotnet test
 ```
 
@@ -182,7 +182,7 @@ this *does* test the locally deployed `Ekgn.NuHello` NuGet package.
 If you wanted to run just this test:
 
 ```powershell
-cd test\Hello.NuTest
+cd test/Hello.NuTest
 dotnet test
 ```
 
@@ -261,9 +261,9 @@ To build the `Ekgn.NuHello.Goodbye` NuGet package and deploy it to the local
 package source, you can run these commands:
 
 ```powershell
-cd src\Goodbye
+cd src/Goodbye
 nuget pack
-nuget add Ekgn.NuHello.Goodbye.1.0.0.nupkg -source ..\..\publish
+nuget add Ekgn.NuHello.Goodbye.1.0.0.nupkg -source ../../publish
 ```
 
 ## test/Goodbye.NuTest
@@ -274,7 +274,7 @@ tests the locally deployed `Ekgn.NuHello.Goodbye` NuGet package.
 If you wanted to run just this test:
 
 ```powershell
-cd test\Goodbye.NuTest
+cd test/Goodbye.NuTest
 dotnet test
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ license.
 
 That applies to all files in this repository, including this README file. The
 code in this repository also has some outside dependencies—mainly
-[xUnit](https://xunit.net/)— which are retrieved automatically as needed. Those
+[xUnit](https://xunit.net/)—which are retrieved automatically as needed. Those
 outside dependencies are covered by other licenses.
 
 ---

--- a/scripts/repackage.ps1
+++ b/scripts/repackage.ps1
@@ -1,0 +1,67 @@
+#!/usr/bin/env pwsh
+
+# Copyright (c) 2023 Eliah Kagan
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# PERFORMANCE OF THIS SOFTWARE.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptName = $MyInvocation.MyCommand.Name
+$Escape = [char]27
+
+function Write-Message($Text) {
+    if ([Console]::IsOutputRedirected) {
+        Write-Output "$Text"
+    } else {
+        Write-Output "${Escape}[1m${Text}${Escape}[0m"
+    }
+}
+
+function Write-Divider {
+    Write-Output ''
+}
+
+function Write-ErrorMessage($Text) {
+    [Console]::Error.WriteLine("${ScriptName}: error: $Text")
+}
+
+# Refuse to run if we are not in the correct directory.
+if (-not (Test-Path NuHello.sln -PathType Leaf)) {
+    Write-ErrorMessage 'not in top-level solution directory'
+    exit 1
+}
+
+Write-Message 'Deleting built package files and clearing NuGet cache.'
+Remove-Item -Recurse -Force src/*/bin,src/*/obj,test/*/bin,test/*/obj,publish/*
+Remove-Item -Force src/Goodbye/*.nupkg
+dotnet nuget locals all --clear || exit $LASTEXITCODE
+Write-Divider
+
+Write-Message 'Rebuilding and locally publishing Hello.'
+Push-Location src/Hello
+dotnet build || exit $LASTEXITCODE
+nuget add bin/Debug/Ekgn.NuHello.1.0.0.nupkg -source ../../publish ||
+    exit $LASTEXITCODE
+Pop-Location
+Write-Divider
+
+Write-Message 'Rebuilding and locally publishing Goodbye.'
+Push-Location src/Goodbye
+nuget pack || exit $LASTEXITCODE
+nuget add Ekgn.NuHello.Goodbye.1.0.0.nupkg -source ../../publish ||
+    exit $LASTEXITCODE
+Pop-Location
+Write-Divider
+
+Write-Message `
+    'Packages rebuilt and locally republished. Run "dotnet test" to test.'

--- a/scripts/repackage.ps1
+++ b/scripts/repackage.ps1
@@ -27,7 +27,7 @@ function Write-Message($Text) {
     }
 }
 
-function Emit-Divider {
+function Write-Divider {
     Write-Output ''
 }
 
@@ -45,7 +45,7 @@ Write-Message 'Deleting built package files and clearing NuGet cache.'
 Remove-Item -Recurse -Force src/*/bin,src/*/obj,test/*/bin,test/*/obj,publish/*
 Remove-Item -Force src/Goodbye/*.nupkg
 dotnet nuget locals all --clear || exit $LASTEXITCODE
-Emit-Divider
+Write-Divider
 
 Write-Message 'Rebuilding and locally publishing Hello.'
 Push-Location src/Hello
@@ -53,7 +53,7 @@ dotnet build || exit $LASTEXITCODE
 nuget add bin/Debug/Ekgn.NuHello.1.0.0.nupkg -source ../../publish ||
     exit $LASTEXITCODE
 Pop-Location
-Emit-Divider
+Write-Divider
 
 Write-Message 'Rebuilding and locally publishing Goodbye.'
 Push-Location src/Goodbye
@@ -61,7 +61,7 @@ nuget pack || exit $LASTEXITCODE
 nuget add Ekgn.NuHello.Goodbye.1.0.0.nupkg -source ../../publish ||
     exit $LASTEXITCODE
 Pop-Location
-Emit-Divider
+Write-Divider
 
 Write-Message `
     'Packages rebuilt and locally republished. Run "dotnet test" to test.'

--- a/scripts/repackage.ps1
+++ b/scripts/repackage.ps1
@@ -27,7 +27,7 @@ function Write-Message($Text) {
     }
 }
 
-function Write-Divider {
+function Emit-Divider {
     Write-Output ''
 }
 
@@ -45,7 +45,7 @@ Write-Message 'Deleting built package files and clearing NuGet cache.'
 Remove-Item -Recurse -Force src/*/bin,src/*/obj,test/*/bin,test/*/obj,publish/*
 Remove-Item -Force src/Goodbye/*.nupkg
 dotnet nuget locals all --clear || exit $LASTEXITCODE
-Write-Divider
+Emit-Divider
 
 Write-Message 'Rebuilding and locally publishing Hello.'
 Push-Location src/Hello
@@ -53,7 +53,7 @@ dotnet build || exit $LASTEXITCODE
 nuget add bin/Debug/Ekgn.NuHello.1.0.0.nupkg -source ../../publish ||
     exit $LASTEXITCODE
 Pop-Location
-Write-Divider
+Emit-Divider
 
 Write-Message 'Rebuilding and locally publishing Goodbye.'
 Push-Location src/Goodbye
@@ -61,7 +61,7 @@ nuget pack || exit $LASTEXITCODE
 nuget add Ekgn.NuHello.Goodbye.1.0.0.nupkg -source ../../publish ||
     exit $LASTEXITCODE
 Pop-Location
-Write-Divider
+Emit-Divider
 
 Write-Message `
     'Packages rebuilt and locally republished. Run "dotnet test" to test.'


### PR DESCRIPTION
So we have both versions.

This also:

- adds related tools
- adds related CI actions
- makes all paths in `README.md` portable

Regarding the last point, note that this does *not* do most of what must be done for #13.