### PR TITLE
Use .NET 6 SDK to fix "--output" error

### DIFF
--- a/.github/workflows/infersharp-global.json
+++ b/.github/workflows/infersharp-global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.406",
+    "rollForward": "latestFeature"
+  }
+}

--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -27,6 +27,11 @@ jobs:
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Put global.json in place
+        run: cp .github/workflows/infersharp-global.json global.json
 
       - name: Build
         run: dotnet build --output binaries-for-infer


### PR DESCRIPTION
This fixes the new error:

> The "--output" option isn't supported when building a solution.

Same fix as in:

- https://github.com/EliahKagan/SharpAvi/pull/5
- https://github.com/EliahKagan/Graph/pull/6