### PR TITLE
Stop grouping Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 20
-    groups:
-      dotnet-dependencies:
-        patterns: ["*"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
They keep generating noop PRs like #55 and #56.